### PR TITLE
Change the size of the header elements in mini-posters

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -232,8 +232,8 @@ function displaySavedPosters() {
     posterElement.classList.add("mini-poster");
     posterElement.innerHTML = `
       <img class="mini-poster-img" src="${poster.imageURL}" alt="Saved Poster">
-      <h4 class="mini-poster-title">${poster.title}</h4>
-      <h5 class="mini-poster-quote">${poster.quote}</h5>
+      <h2 class="mini-poster-title">${poster.title}</h2>
+      <h4 class="mini-poster-quote">${poster.quote}</h4>
     `;
     savedPostersGrid.appendChild(posterElement);
   }


### PR DESCRIPTION
Hey Avery, I went back and updated the mini-poster html elements to be slightly larger to match the proportions of the full-size posters on the main page.  I dropped some screenshots below to compare those changes visually. 
![Screenshot 2023-05-21 at 8 26 20 PM](https://github.com/Averyberryman/hang-in-there-JenAveryPairProject/assets/130857864/71d2f835-7afe-40a1-a1dd-154f09c7dcbf)
![Screenshot 2023-05-22 at 9 38 10 AM](https://github.com/Averyberryman/hang-in-there-JenAveryPairProject/assets/130857864/61ea1009-5707-4976-a71c-ca880df8eb7f)
